### PR TITLE
Removing Ldio:ConsoleOut outputs

### DIFF
--- a/ldio-ldes2triplestore.yml
+++ b/ldio-ldes2triplestore.yml
@@ -54,10 +54,10 @@ orchestrator:
             }
             "
       outputs:
-        - name: Ldio:ConsoleOut
-          config:
-            rdf-writer:
-              content-type: application/n-quads
+    #  - name: Ldio:ConsoleOut
+    #      config:
+    #        rdf-writer:
+    #          content-type: application/n-quads
         - name: Ldio:RepositorySink
           config:
             sparql-host: http://rdf4j-server:8080/rdf4j-server
@@ -77,7 +77,7 @@ orchestrator:
         adapter:
             name: Ldio:RdfAdapter
       outputs:
-        - name: Ldio:ConsoleOut
+      # - name: Ldio:ConsoleOut
         - name: Ldio:RepositorySink
           config:
             sparql-host: http://rdf4j-server:8080/rdf4j-server


### PR DESCRIPTION
Put Ldio:ConsoleOut in comments for both pipelines as it tends to drastically slow down a fresh LDES client synching with the server